### PR TITLE
Agregar DER8 (NUEVO PENSUM) de Derecho y actualizar referencia de enlace

### DIFF
--- a/lib/data/pensum-pages.ts
+++ b/lib/data/pensum-pages.ts
@@ -4,6 +4,7 @@ export const pensumPages: Record<string, string> = {
 	ATH11: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/ATH',
 	CDG11: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/CDG10',
 	CON11: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/CON',
+	DER8: 'https://unapec.edu.do/academia/programas-de-grado/licenciatura-en-derecho/',
 	DER7: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/DEr',
 	DIG11: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/DIG',
 	DIN11: 'https://servicios.unapec.edu.do/pensum/Main/Detalles/DIN',

--- a/lib/data/pensums.json
+++ b/lib/data/pensums.json
@@ -10120,5 +10120,535 @@
 				]
 			}
 		]
+	},
+	{
+		"carreerName": "LICENCIATURA EN DERECHO (NUEVO PENSUM)",
+		"totalCredits": 212,
+		"pensumCode": "DER8",
+		"date": "2026-04-14T00:00:00.000Z",
+		"cuatris": [
+			{
+				"period": 1,
+				"subjects": [
+					{
+						"code": "DER480",
+						"name": "INTRODUCCION AL ESTUDIO DEL DERECHO",
+						"credits": 4,
+						"prerequisites": []
+					},
+					{
+						"code": "ENG000",
+						"name": "FUNDAMENTOS DE INGLES (I Y II)",
+						"credits": 0,
+						"prerequisites": []
+					},
+					{
+						"code": "ESP101",
+						"name": "ANALISIS DE TEXTOS DISCURSIVOS",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "MAT010",
+						"name": "MATEMATICA BASICA UNIVERSITARIA",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "SOC011",
+						"name": "HISTORIA SOCIAL DOMINICANA",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "SOC030",
+						"name": "ORIENTACION UNIVERSITARIA",
+						"credits": 2,
+						"prerequisites": []
+					},
+					{
+						"code": "SOC043",
+						"name": "GESTION AMBIENTAL",
+						"credits": 2,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 2,
+				"subjects": [
+					{
+						"code": "DER115",
+						"name": "DERECHO DE LAS PERSONAS",
+						"credits": 4,
+						"prerequisites": ["DER480"]
+					},
+					{
+						"code": "DER135",
+						"name": "DERECHO ROMANO",
+						"credits": 2,
+						"prerequisites": []
+					},
+					{
+						"code": "DER182",
+						"name": "TEORIA GENERAL DE DERECHO",
+						"credits": 3,
+						"prerequisites": ["DER480"]
+					},
+					{
+						"code": "ENG003",
+						"name": "INGLES III",
+						"credits": 0,
+						"prerequisites": ["ENG000"]
+					},
+					{
+						"code": "ESP106",
+						"name": "REDACCION DE TEXTOS DISCURSIVOS I",
+						"credits": 3,
+						"prerequisites": ["ESP101"]
+					},
+					{
+						"code": "SOC013",
+						"name": "FILOSOFIA",
+						"credits": 2,
+						"prerequisites": []
+					},
+					{
+						"code": "SOC101",
+						"name": "INTRODUCCION A LA PSICOLOGIA",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "ODEP",
+						"name": "OPTATIVA DEPORTE",
+						"credits": 0,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 3,
+				"subjects": [
+					{
+						"code": "ADM535",
+						"name": "ACTITUD EMPRENDEDORA",
+						"credits": 3,
+						"prerequisites": ["SOC101"]
+					},
+					{
+						"code": "DER164",
+						"name": "DERECHO CONSTITUCIONAL I",
+						"credits": 3,
+						"prerequisites": ["DER115", "DER480"]
+					},
+					{
+						"code": "DER400",
+						"name": "HISTORIA DE LAS IDEAS POLITICAS Y DE LAS INSTITUCIONES DOMINICANAS",
+						"credits": 4,
+						"prerequisites": ["SOC011"]
+					},
+					{
+						"code": "DER410",
+						"name": "DERECHO DE FAMILIA, DE LA NIÑEZ Y ADOLESCENCIA",
+						"credits": 4,
+						"prerequisites": ["DER115"]
+					},
+					{
+						"code": "ENG004",
+						"name": "INGLES IV",
+						"credits": 0,
+						"prerequisites": ["ENG003"]
+					},
+					{
+						"code": "ESP107",
+						"name": "REDACCION DE TEXTOS DISCURSIVOS II",
+						"credits": 3,
+						"prerequisites": ["ESP106"]
+					},
+					{
+						"code": "SOC200",
+						"name": "INTRODUCCION A LA SOCIOLOGIA",
+						"credits": 3,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 4,
+				"subjects": [
+					{
+						"code": "DER165",
+						"name": "DERECHO CONSTITUCIONAL II",
+						"credits": 3,
+						"prerequisites": ["DER164"]
+					},
+					{
+						"code": "DER490",
+						"name": "LOGICA JURIDICA",
+						"credits": 3,
+						"prerequisites": ["DER164", "DER182"]
+					},
+					{
+						"code": "DER500",
+						"name": "DERECHO DE LOS REGIMENES MATRIMONIALES",
+						"credits": 3,
+						"prerequisites": ["DER410"]
+					},
+					{
+						"code": "DER510",
+						"name": "DERECHO OBLIGACIONES I",
+						"credits": 3,
+						"prerequisites": ["DER182", "DER410"]
+					},
+					{
+						"code": "DER511",
+						"name": "DERECHO PENAL GENERAL I",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "ENG005",
+						"name": "INGLES V",
+						"credits": 0,
+						"prerequisites": ["ENG004"]
+					},
+					{
+						"code": "SOC253",
+						"name": "METODOLOGIA Y TECNICAS DE INVESTIGACION",
+						"credits": 4,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 5,
+				"subjects": [
+					{
+						"code": "DER168",
+						"name": "DERECHO ADMINISTRATIVO I",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER174",
+						"name": "DERECHO PROCESAL CONSTITUCIONAL",
+						"credits": 3,
+						"prerequisites": ["DER165"]
+					},
+					{
+						"code": "DER227",
+						"name": "DERECHO LABORAL I",
+						"credits": 3,
+						"prerequisites": ["DER510"]
+					},
+					{
+						"code": "DER237",
+						"name": "DERECHO COMERCIAL I",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER248",
+						"name": "DERECHO INTERNACIONAL PUBLICO",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER420",
+						"name": "DERECHO PENAL GENERAL Y CRIMINOLOGIA ERA II",
+						"credits": 4,
+						"prerequisites": ["DER511"]
+					},
+					{
+						"code": "DER515",
+						"name": "DERECHO OBLIGACIONES II",
+						"credits": 3,
+						"prerequisites": ["DER510"]
+					},
+					{
+						"code": "ENG006",
+						"name": "INGLES VI",
+						"credits": 0,
+						"prerequisites": ["ENG005"]
+					}
+				]
+			},
+			{
+				"period": 6,
+				"subjects": [
+					{
+						"code": "DER154",
+						"name": "DERECHO PROCESAL CIVIL I",
+						"credits": 4,
+						"prerequisites": ["DER515"]
+					},
+					{
+						"code": "DER169",
+						"name": "DERECHO ADMINISTRATIVO II",
+						"credits": 3,
+						"prerequisites": ["DER168"]
+					},
+					{
+						"code": "DER186",
+						"name": "DERECHO PENAL ESPECIAL I",
+						"credits": 3,
+						"prerequisites": ["DER420"]
+					},
+					{
+						"code": "DER238",
+						"name": "DERECHO COMERCIAL II",
+						"credits": 3,
+						"prerequisites": ["DER237"]
+					},
+					{
+						"code": "DER470",
+						"name": "DERECHO LABORAL Y SU PROCEDIMIENTO",
+						"credits": 4,
+						"prerequisites": ["DER227"]
+					},
+					{
+						"code": "DER525",
+						"name": "DERECHO OBLIGACIONES III",
+						"credits": 3,
+						"prerequisites": ["DER515"]
+					},
+					{
+						"code": "ENG007",
+						"name": "INGLES VII",
+						"credits": 0,
+						"prerequisites": ["ENG006"]
+					}
+				]
+			},
+			{
+				"period": 7,
+				"subjects": [
+					{
+						"code": "DER155",
+						"name": "DERECHO PROCESAL CIVIL II",
+						"credits": 4,
+						"prerequisites": ["DER154"]
+					},
+					{
+						"code": "DER178",
+						"name": "DERECHOS REALES",
+						"credits": 4,
+						"prerequisites": ["DER525"]
+					},
+					{
+						"code": "DER187",
+						"name": "DERECHO PENAL ESPECIAL II",
+						"credits": 3,
+						"prerequisites": ["DER186"]
+					},
+					{
+						"code": "DER301",
+						"name": "ETICA JURIDICA",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER535",
+						"name": "DERECHO FISCAL",
+						"credits": 4,
+						"prerequisites": ["DER169"]
+					},
+					{
+						"code": "ENG008",
+						"name": "INGLES VIII",
+						"credits": 0,
+						"prerequisites": ["ENG007"]
+					},
+					{
+						"code": "SOC260",
+						"name": "SOCIOLOGIA JURIDICA",
+						"credits": 2,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 8,
+				"subjects": [
+					{
+						"code": "DER210",
+						"name": "DERECHO PROCESAL ADM. Y FISCAL",
+						"credits": 3,
+						"prerequisites": ["DER169", "DER535"]
+					},
+					{
+						"code": "DER430",
+						"name": "DERECHO DE REGISTRO INMOBILIARIO",
+						"credits": 3,
+						"prerequisites": ["DER525"]
+					},
+					{
+						"code": "DER530",
+						"name": "DERECHO INTERNACIONAL PRIVADO",
+						"credits": 3,
+						"prerequisites": ["DER248"]
+					},
+					{
+						"code": "DER532",
+						"name": "DERECHO PROPIEDAD INTELECTUAL",
+						"credits": 3,
+						"prerequisites": ["DER155"]
+					},
+					{
+						"code": "DER540",
+						"name": "DERECHO PROCESAL PENAL I",
+						"credits": 4,
+						"prerequisites": ["DER187"]
+					},
+					{
+						"code": "DER545",
+						"name": "DERECHO PROCESAL CIVIL III",
+						"credits": 3,
+						"prerequisites": ["DER155"]
+					},
+					{
+						"code": "ENG009",
+						"name": "INGLES IX",
+						"credits": 0,
+						"prerequisites": ["ENG008"]
+					}
+				]
+			},
+			{
+				"period": 9,
+				"subjects": [
+					{
+						"code": "DER152",
+						"name": "DERECHO AMBIENTAL",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER197",
+						"name": "DERECHO PROCESAL PENAL II",
+						"credits": 3,
+						"prerequisites": ["DER540"]
+					},
+					{
+						"code": "DER230",
+						"name": "ARBITRAJE INTERNACIONAL",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER546",
+						"name": "DERECHO PROCESAL CIVIL IV",
+						"credits": 3,
+						"prerequisites": ["DER545"]
+					},
+					{
+						"code": "DER550",
+						"name": "DERECHO DE LAS GARANTIAS",
+						"credits": 3,
+						"prerequisites": ["DER525"]
+					},
+					{
+						"code": "DER555",
+						"name": "DERECHO DE LOS PRINCIPALES CONTRATOS",
+						"credits": 3,
+						"prerequisites": ["DER525"]
+					},
+					{
+						"code": "ENG010",
+						"name": "INGLES X",
+						"credits": 0,
+						"prerequisites": ["ENG009"]
+					}
+				]
+			},
+			{
+				"period": 10,
+				"subjects": [
+					{
+						"code": "DER151",
+						"name": "DERECHO TELECOMUNICACION Y TECNOLOGIA INFORMACION",
+						"credits": 3,
+						"prerequisites": []
+					},
+					{
+						"code": "DER281",
+						"name": "DERECHO COMPARADO",
+						"credits": 3,
+						"prerequisites": ["DER550"]
+					},
+					{
+						"code": "DER440",
+						"name": "PRACTICA JURIDICA DE SERVICIOS JUDICIALES I",
+						"credits": 5,
+						"prerequisites": ["DER546"]
+					},
+					{
+						"code": "SOC281",
+						"name": "SEMINARIO DE GRADO",
+						"credits": 3,
+						"prerequisites": ["SOC253", "80% De los créditos aprobados"]
+					},
+					{
+						"code": "E018",
+						"name": "ELECTIVA I",
+						"credits": 3,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 11,
+				"subjects": [
+					{
+						"code": "DER204",
+						"name": "DERECHOS HUMANOS",
+						"credits": 3,
+						"prerequisites": ["DER281"]
+					},
+					{
+						"code": "DER275",
+						"name": "DERECHO DE SUCESIONES Y LIBERALIDADES",
+						"credits": 4,
+						"prerequisites": ["DER410", "DER546"]
+					},
+					{
+						"code": "DER450",
+						"name": "PRACTICA JURIDICA DE SERVICIOS JUDICIALES II",
+						"credits": 5,
+						"prerequisites": ["DER440"]
+					},
+					{
+						"code": "DER556",
+						"name": "LEGISLACION BANCARIA Y DE SEGUROS",
+						"credits": 2,
+						"prerequisites": []
+					},
+					{
+						"code": "E019",
+						"name": "ELECTIVA II",
+						"credits": 3,
+						"prerequisites": []
+					}
+				]
+			},
+			{
+				"period": 12,
+				"subjects": [
+					{
+						"code": "TFG",
+						"name": "TRABAJO FINAL DE GRADO",
+						"credits": 6,
+						"prerequisites": []
+					},
+					{
+						"code": "PAS100",
+						"name": "PASANTIA DE LICENCIATURA EN DERECHO",
+						"credits": 0,
+						"prerequisites": []
+					}
+				]
+			}
+		]
 	}
 ]


### PR DESCRIPTION
**Se agrega una nueva versión del pensum de Derecho con código DER8, manteniendo DER7 sin cambios.**

**Cambios realizados:**
Se añadió el pensum DER8 con 12 cuatrimestres.
Se incluyó la etiqueta visual “(NUEVO PENSUM)” en el nombre de la carrera.
Se agregó el mapeo de DER8 en pensum-pages para mostrar el enlace de referencia en la tarjeta de información.
Se mantuvo una sola fila de ESP106 en 2do cuatrimestre para evitar duplicidad de código.

**Notas:**
DER7 permanece disponible para no romper compatibilidad histórica.
Como no hay una fecha oficial pública del nuevo pensum, se usó la fecha del día del commit como fecha de carga.